### PR TITLE
Setup plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ requests_).
 
 <!-- start-shortlog -->
  - Oliver Sanders
+ - Violet Sherratt
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/README.md
+++ b/README.md
@@ -8,6 +8,34 @@
 [![Chat](https://img.shields.io/matrix/cylc-general:matrix.org)](https://matrix.to/#/#cylc-general:matrix.org)
 
 
+### Installation
+
+It is recommended to install as a Vim package
+(see [`:help packages`](https://vimhelp.org/repeat.txt.html#packages)):
+
+```bash
+mkdir -p ~/.vim/pack/vendor/start
+cd ~/.vim/pack/vendor/start
+git clone https://github.com/cylc/cylc.vim.git
+```
+
+Otherwise, use your favourite plugin manager, such as
+[pathogen.vim](https://github.com/tpope/vim-pathogen).
+
+
+### Usage
+
+Cylc syntax is linked to standard vim highlighting groups, so should already be
+consistent with any colour scheme.
+
+Syntax-based folding is enabled; if you want to open files with folds initially
+open, then add the following line to your vimrc:
+
+```vim
+set foldlevelstart=99
+```
+
+
 ### Developing
 
 Contributions welcome, read the [contributing](CONTRIBUTING.md) page and

--- a/ftdetect/cylc.vim
+++ b/ftdetect/cylc.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *suite*.rc,*.cylc set filetype=cylc

--- a/ftplugin/cylc.vim
+++ b/ftplugin/cylc.vim
@@ -1,4 +1,4 @@
-" Simple indentation
+" Simple indentation, overridden if `:filetype indent` is also set
 setlocal autoindent
 
 " Includes

--- a/ftplugin/cylc.vim
+++ b/ftplugin/cylc.vim
@@ -1,0 +1,17 @@
+" Simple indentation
+setlocal autoindent
+
+" Includes
+setlocal include=^\\s*%include
+
+" Comments start with `#`
+setlocal commentstring=#%s
+setlocal comments=:#
+" ... so don't bother reindenting on `#`
+setlocal indentkeys-=0#
+setlocal cinkeys-=0#
+
+" Don't autowrap text
+setlocal formatoptions-=t
+" Do format comments
+setlocal formatoptions+=croql

--- a/indent/cylc.vim
+++ b/indent/cylc.vim
@@ -1,0 +1,68 @@
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+" Some preliminary settings
+setlocal nolisp      " Make sure lisp indenting doesn't supersede us
+setlocal autoindent  " indentexpr isn't much help otherwise
+
+setlocal indentexpr=GetCylcIndent(v:lnum)
+setlocal indentkeys=!^F,o,O,]
+
+" Only define the function once.
+if exists("*GetCylcIndent")
+  finish
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function s:header_level(lnum)
+  " Level of the section header on a given line, 0 if none
+  let line = getline(a:lnum)
+  return substitute(line, '^\s*\(\[*\).*', '\=strlen(submatch(1))', '')
+endfunction
+
+function s:prev_header(lnum)
+  " Jump to the header preceding a given line
+  call cursor(a:lnum, 1)
+  return search('^\s*\[\+', "bW")
+endfunction
+
+function GetCylcIndent(lnum)
+  let line = getline(a:lnum)
+  let line = substitute(line, '\v^\s+|\s+$', '', 'g')
+
+  " Do not adjust jinja indentation
+  if line =~ '^\({{|{%\)'
+    return -1
+  endif
+
+  " Check for a section header on this line
+  let level = s:header_level(a:lnum)
+  if level > 0
+    return shiftwidth() * (level - 1)
+  endif
+
+  " Otherwise, find the nearest section header
+  let level = s:header_level(s:prev_header(a:lnum))
+
+  " Add an extra indent inside multiline strings, not including closing
+  " quotes if on their own line
+  if has('syntax_items')
+    if synIDattr(synID(a:lnum, 1, 1), "name") =~ "String"
+      if line != '"""'
+        let level = level + 1
+      endif
+    endif
+  endif
+
+  return shiftwidth() * level
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: et sw=2 ts=2 sts=2

--- a/indent/cylc.vim
+++ b/indent/cylc.vim
@@ -9,7 +9,7 @@ setlocal nolisp      " Make sure lisp indenting doesn't supersede us
 setlocal autoindent  " indentexpr isn't much help otherwise
 
 setlocal indentexpr=GetCylcIndent(v:lnum)
-setlocal indentkeys=!^F,o,O,]
+setlocal indentkeys=!^F,o,O,],\",'
 
 " Only define the function once.
 if exists("*GetCylcIndent")
@@ -29,6 +29,18 @@ function s:prev_header(lnum)
   " Jump to the header preceding a given line
   call cursor(a:lnum, 1)
   return search('^\s*\[\+', "bW")
+endfunction
+
+function s:is_in_multistring(lnum)
+  " Check whether a given line makes up a multi-line string
+  if has('syntax_items')
+    for id in synstack(a:lnum, 1)
+      if synIDattr(id, "name") =~ "String"
+        return 1
+      endif
+    endfor
+  endif
+  return 0
 endfunction
 
 function GetCylcIndent(lnum)
@@ -51,11 +63,9 @@ function GetCylcIndent(lnum)
 
   " Add an extra indent inside multiline strings, not including closing
   " quotes if on their own line
-  if has('syntax_items')
-    if synIDattr(synID(a:lnum, 1, 1), "name") =~ "String"
-      if line != '"""'
-        let level = level + 1
-      endif
+  if s:is_in_multistring(a:lnum)
+    if line != '"""' && line != "'''"
+      let level = level + 1
     endif
   endif
 

--- a/indent/cylc.vim
+++ b/indent/cylc.vim
@@ -47,8 +47,8 @@ function GetCylcIndent(lnum)
   let line = getline(a:lnum)
   let line = substitute(line, '\v^\s+|\s+$', '', 'g')
 
-  " Do not adjust jinja indentation
-  if line =~ '^\({{|{%\)'
+  " Do not adjust jinja or empy indentation
+  if line =~ '^\({[{%#]\|@[[({]\)'
     return -1
   endif
 

--- a/indent/cylc.vim
+++ b/indent/cylc.vim
@@ -74,5 +74,3 @@ endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
-
-" vim: et sw=2 ts=2 sts=2

--- a/syntax/cylc.vim
+++ b/syntax/cylc.vim
@@ -49,10 +49,11 @@ syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinj
 
 syn region cylcString start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
 syn region cylcString start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
-syn region cylcString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
-syn region cylcString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
+syn region cylcMultiString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
+syn region cylcMultiString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
 
-"de-emphasize strings as quoting is irrelevant in cylc
+hi def link cylcMultiString String
+" de-emphasize regular strings as quoting is irrelevant in cylc
 hi def link cylcString Normal
 
 hi def link cylcSection Statement

--- a/syntax/cylc.vim
+++ b/syntax/cylc.vim
@@ -1,35 +1,6 @@
 " Syntax highlighting for Cylc files.
 " Author: Hilary Oliver, 2011-2014
 " see :help syntax
-"______________________________________________________________________
-"
-"INSTRUCTIONS FOR USE
-"
-" 1) Put this file in $HOME/.vim/syntax/ directory.
-"
-" 2) Put the following in $HOME/.vimrc for file type recognition
-"    (without the leading "| characters):
-"
-"|augroup filetype
-"|  au! BufRead,BufnewFile *suite*.rc   set filetype=cylc
-"|  au! BufRead,BufnewFile *.cylc   set filetype=cylc
-"|augroup END
-"
-" 3) If you want to open files with syntax folds initially open, then
-"    also add the following line to your $HOME/.vimrc file:
-"
-"|if has("folding") | set foldlevelstart=99 | endif
-"
-" 4) Cylc syntax is linked to standard vim highlighting groups below (e.g.
-" comments: 'hi def link cylcComment Comment'). These can be customized in
-"  your .vimrc file for consistent highlighting across file types, e.g.:
-"
-"|hi Statement guifg=#22a8e3 gui=bold
-"|hi Normal guifg=#9096a4
-"|hi Comment guifg=#ff6900
-"|hi Type guifg=#28d45b gui=bold"
-"
-"______________________________________________________________________
 
 " syncing from start of file is best, but may be slow for large files:
 syn sync fromstart

--- a/syntax/cylc.vim
+++ b/syntax/cylc.vim
@@ -1,0 +1,105 @@
+" Syntax highlighting for Cylc files.
+" Author: Hilary Oliver, 2011-2014
+" see :help syntax
+"______________________________________________________________________
+"
+"INSTRUCTIONS FOR USE
+"
+" 1) Put this file in $HOME/.vim/syntax/ directory.
+"
+" 2) Put the following in $HOME/.vimrc for file type recognition
+"    (without the leading "| characters):
+"
+"|augroup filetype
+"|  au! BufRead,BufnewFile *suite*.rc   set filetype=cylc
+"|  au! BufRead,BufnewFile *.cylc   set filetype=cylc
+"|augroup END
+"
+" 3) If you want to open files with syntax folds initially open, then
+"    also add the following line to your $HOME/.vimrc file:
+"
+"|if has("folding") | set foldlevelstart=99 | endif
+"
+" 4) Cylc syntax is linked to standard vim highlighting groups below (e.g.
+" comments: 'hi def link cylcComment Comment'). These can be customized in
+"  your .vimrc file for consistent highlighting across file types, e.g.:
+"
+"|hi Statement guifg=#22a8e3 gui=bold
+"|hi Normal guifg=#9096a4
+"|hi Comment guifg=#ff6900
+"|hi Type guifg=#28d45b gui=bold"
+"
+"______________________________________________________________________
+
+" syncing from start of file is best, but may be slow for large files:
+syn sync fromstart
+
+set foldmethod=syntax
+syn region myFold start='\_^ *\[\[\[\(\w\| \)' end='\ze\_^ *\[\{1,3}\(\w\| \)' transparent fold
+syn region myFold start='\_^ *\[\[\(\w\| \)' end='\ze\_^ *\[\{1,2}\(\w\| \)' transparent fold
+syn region myFold start='\_^ *\[\(\w\| \)' end='\_^ *\ze\[\(\w\| \)' transparent fold
+
+" note contained items are only recognized inside containing items
+syn match lineCon "\\$"
+syn match badLineCon "\\ \+$"
+syn match trailingWS " \+\(\n\)\@="
+
+syn region jinja2 start='{%' end='%}'
+syn region jinja2 start='{{' end='}}'
+syn region jinja2 start='{#' end='#}'
+
+syn region empy start='@\[' end=']'
+syn region empy start='@{' end='}'
+syn region empy start='@(' end=')'
+
+syn region cylcSection start='\[' end='\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
+syn region cylcSection start='\[\[' end='\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
+syn region cylcSection start='\[\[\[' end='\]\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
+
+syn match cylcItem ' *\zs\(\w\| \|\-\)*\> *=\@='
+syn match cylcEquals '='
+
+syn match trigger /=>/ contained
+syn match output /:[a-zA-Z0-9-]*\>/ contained
+syn match suicide /\!\w\+/ contained
+syn match offset /\[.\{-}\]/ contained
+
+"file inclusion:
+syn match cylcInclude '%include *\(\w\|\-\|\/\|\.\)*'
+"inlined file markers:
+syn match cylcInclude '\_^!\{1,}'
+syn match cylcInclude '.*\(START INLINED\|END INLINED\).*'
+
+syn match cylcToDo /[Tt][Oo][Dd][Oo]/
+
+syn match empyVariable /@[a-zA-Z0-9]\+/
+syn match empyComment /@#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon
+syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2,empy
+
+syn region cylcString start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
+syn region cylcString start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
+syn region cylcString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
+syn region cylcString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
+
+"de-emphasize strings as quoting is irrelevant in cylc
+hi def link cylcString Normal
+
+hi def link cylcSection Statement
+hi def link cylcItem Type
+hi def link cylcComment Comment
+
+hi def link lineCon Constant
+hi def link badLineCon Error
+hi def link trailingWS Underlined
+
+hi def link cylcToDo Todo
+hi def link cylcInclude MatchParen
+hi def link jinja2 CursorColumn
+hi def link empy CursorColumn
+hi def link empyComment CursorColumn
+hi def link empyVariable CursorColumn
+hi def link cylcEquals LineNr
+hi def link output Special
+hi def link suicide Special
+hi def link offset Special
+hi def link trigger Constant

--- a/syntax/cylc.vim
+++ b/syntax/cylc.vim
@@ -15,42 +15,46 @@ syn match lineCon "\\$"
 syn match badLineCon "\\ \+$"
 syn match trailingWS " \+\(\n\)\@="
 
-syn region jinja2 start='{%' end='%}'
-syn region jinja2 start='{{' end='}}'
-syn region jinja2 start='{#' end='#}'
+syn region jinja2Block start='{%' end='%}'
+syn region jinja2Print start='{{' end='}}'
+syn region jinja2Comment start='{#' end='#}'
 
 syn region empy start='@\[' end=']'
 syn region empy start='@{' end='}'
 syn region empy start='@(' end=')'
 
-syn region cylcSection start='\[' end='\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
-syn region cylcSection start='\[\[' end='\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
-syn region cylcSection start='\[\[\[' end='\]\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,empy
+syn region cylcSection start='\[' end='\]' contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy
+syn region cylcSection start='\[\[' end='\]\]' contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy
+syn region cylcSection start='\[\[\[' end='\]\]\]' contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy
 
-syn match cylcItem ' *\zs\(\w\| \|\-\)*\> *=\@='
+syn match cylcItem ' *\zs\(\w\|+\|\/\| \|\-\)*\> *=\@='
 syn match cylcEquals '='
 
 syn match trigger /=>/ contained
-syn match output /:[a-zA-Z0-9-]*\>/ contained
+syn match xtrigger /@[a-zA-Z0-9_-]*/ contained
+syn match parameter /<[^>]*>/ contained
+syn match output /:[a-zA-Z0-9_-]*\>/ contained
 syn match suicide /\!\w\+/ contained
 syn match offset /\[.\{-}\]/ contained
+syn match optional /?/ contained
 
 "file inclusion:
-syn match cylcInclude '%include *\(\w\|\-\|\/\|\.\)*'
+syn match cylcInclude '%include *\(\w\|"\| \|\-\|\/\|\.\)*'
 "inlined file markers:
 syn match cylcInclude '\_^!\{1,}'
 syn match cylcInclude '.*\(START INLINED\|END INLINED\).*'
 
 syn match cylcToDo /[Tt][Oo][Dd][Oo]/
+syn match cylcToDo /[Ff][Ii][Xx][Mm][Ee]/
 
 syn match empyVariable /@[a-zA-Z0-9]\+/
 syn match empyComment /@#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon
-syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2,empy
+syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy
 
-syn region cylcString start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
-syn region cylcString start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,cylcToDo
-syn region cylcMultiString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
-syn region cylcMultiString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,empy,empyComment,cylcComment,trigger,output,suicide,offset,cylcToDo
+syn region cylcString start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy,cylcToDo
+syn region cylcString start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy,cylcToDo
+syn region cylcMultiString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy,empyComment,cylcComment,optional,trigger,output,suicide,offset,cylcToDo,xtrigger,parameter
+syn region cylcMultiString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2Block,jinja2Print,jinja2Comment,empy,empyComment,cylcComment,optional,trigger,output,suicide,offset,cylcToDo,xtrigger,parameter
 
 hi def link cylcMultiString String
 " de-emphasize regular strings as quoting is irrelevant in cylc
@@ -65,13 +69,19 @@ hi def link badLineCon Error
 hi def link trailingWS Underlined
 
 hi def link cylcToDo Todo
-hi def link cylcInclude MatchParen
-hi def link jinja2 CursorColumn
-hi def link empy CursorColumn
+hi def link cylcInclude Include
+hi def link jinja2Block PreProc
+hi def link jinja2Print PreProc
+hi def link jinja2Comment Comment
+hi def link empy PreProc
 hi def link empyComment CursorColumn
-hi def link empyVariable CursorColumn
+hi def link empyVariable PreProc
 hi def link cylcEquals LineNr
-hi def link output Special
+hi def link output Identifier
 hi def link suicide Special
 hi def link offset Special
 hi def link trigger Constant
+hi def link optional Type
+
+hi def link xtrigger Function
+hi def link parameter Function


### PR DESCRIPTION
Initial setup of a plugin

- Automatic detection in `ftdetect/cylc.vim`
- [Current syntax file](https://github.com/cylc/cylc-flow/blob/125c4434f863cdcf3cabf0d088931684ac5a001a/cylc/flow/etc/syntax/cylc.vim) copied to `syntax/cylc.vim`
  - New syntax group `cylcMultiString` for triple-quoted strings, which is linked to `String`, unlike single-quoted strings which are not highlighed at all
- Simple local settings in `ftplugin/cylc.vim` (for `:filetype plugin`)
- Recommended indentation in `indent/cylc.vim` (for `:filetype indent`)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
