### PR TITLE
set 4 space indent

### DIFF
--- a/indent/cylc.vim
+++ b/indent/cylc.vim
@@ -11,6 +11,8 @@ setlocal autoindent  " indentexpr isn't much help otherwise
 setlocal indentexpr=GetCylcIndent(v:lnum)
 setlocal indentkeys=!^F,o,O,],\",'
 
+setlocal tabstop=4 softtabstop=4 shiftwidth=4
+
 " Only define the function once.
 if exists("*GetCylcIndent")
   finish


### PR DESCRIPTION
Set a language-specific indentation (to override any editor defaults) for Cylc.

The Cylc style guide / linter enforces four space indentation, so this seems reasonable.